### PR TITLE
Add option to whitelist a directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or
     {
       resolve: 'gatsby-plugin-svgr',
       options: {
-        dir: '/some/path' // only process this directory
+        dir: '/some/path', // only process this directory
         // svgr options
         icon: true,
         viewBox: false,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# gatsby-plugin-svgr
+# gatsby-plugin-svgr [![npm version](https://badge.fury.io/js/gatsby-plugin-svgr.svg)](https://badge.fury.io/js/gatsby-plugin-svgr)
+
+[svgr](https://github.com/smooth-code/svgr) plugin for [gatsby](https://www.gatsbyjs.org/)
 
 ## Installing
 ```
@@ -19,9 +21,10 @@ or
     {
       resolve: 'gatsby-plugin-svgr',
       options: {
-        semi: false,
-        singleQuote: true,
-        ref: true,
+        dir: '/some/path' // only process this directory
+        // svgr options
+        icon: true,
+        viewBox: false,
         // see https://github.com/smooth-code/svgr for a list of all options
       },
     },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,8 @@
-exports.modifyWebpackConfig = function(webpack, options) {
-  webpack.config.loader('url-loader', {
+exports.modifyWebpackConfig = ({ config }, options) => {
+  const { plugins, dir, ...svgrOptions } = options;
+
+  // remove gatsby's url-loader loader for svgs
+  config.loader('url-loader', {
     test: /\.(jpg|jpeg|png|gif|mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
     loader: 'url',
     query: {
@@ -8,11 +11,27 @@ exports.modifyWebpackConfig = function(webpack, options) {
     },
   });
 
-  webpack.config.loader('svgr', {
+  // only use svgr's loader for svgs in 'dir' if specified
+  config.loader('svgr', {
     test: /\.svg$/,
-    include: /src/,
-    loaders: ['babel-loader', `svgr/webpack?${JSON.stringify(options)}`],
+    include: dir && new RegExp(dir),
+    loaders: [
+      'babel-loader',
+      `svgr/webpack?${JSON.stringify(svgrOptions)}`,
+    ],
   });
 
-  return webpack.config;
+  if (dir) {
+    config.loader('svg-url', {
+      test: /\.svg$/,
+      exclude: new RegExp(dir),
+      loader: 'url',
+      query: {
+        limit: 10000,
+        name: 'static/[name].[hash:8].[ext]',
+      },
+    });
+  }
+
+  return config;
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,6 +2,7 @@ exports.modifyWebpackConfig = ({ config }, options) => {
   const { plugins, dir, ...svgrOptions } = options;
 
   // remove gatsby's url-loader loader for svgs
+  config.removeLoader('url-loader');
   config.loader('url-loader', {
     test: /\.(jpg|jpeg|png|gif|mp4|webm|wav|mp3|m4a|aac|oga)(\?.*)?$/,
     loader: 'url',


### PR DESCRIPTION
Closes #3 

If a directory is specified using the ```dir``` option, only that directory will be processed. By default, all svgs are processed with svgr if the plugin is enabled.

I also updated the readme.