### PR TITLE
Compatibility with SVGR 2.0.0

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -19,7 +19,7 @@ exports.modifyWebpackConfig = ({ config }, options) => {
       `babel-loader?${JSON.stringify({
         presets: ['env', 'react', 'stage-0'],
       })}`,
-      `svgr/webpack?${JSON.stringify(svgrOptions)}`,
+      `@svgr/webpack?${JSON.stringify(svgrOptions)}`,
       `url?${JSON.stringify(urlQuery)}`,
     ],
   })

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "svgr": "*"
+    "@svgr/webpack": "*"
   }
 }


### PR DESCRIPTION
Currently, installation of the plugin fails. That's because SVGR was updated to v2.0.0 some days ago, now using multiple scoped packages. This PR updates those dependency names from `svgr` to `@svgr/webpack`.