### PR TITLE
Working Gatsby 2.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+yarn.lock
+yarn-error.log

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "svgr"
   ],
   "license": "MIT",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "dependencies": {
     "@svgr/webpack": "*"
+  },
+  "peerDependencies": {
+    "gatsby": ">2.0.0-alpha"
   }
 }


### PR DESCRIPTION
Building on the work from #18, but resolving some issues that preventing that from working.

Note: I had to explicitly add `@babel/plugin-transform-react-constant-elements` to my package.json to get this to work; it's [a dependency](https://github.com/smooth-code/svgr/blob/master/packages/webpack/package.json#L27) of `@svgr/webpack` (not a peer dep) so I'm not sure why this is.