### PR TITLE
Limit SVGR webpack package version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@svgr/webpack": "*"
+    "@svgr/webpack": "^4.0.0"
   },
   "peerDependencies": {
     "gatsby": ">2.0.0-alpha"


### PR DESCRIPTION
Using a wildcard version range for the dependency breaks the usage when a new major version is released. This has been the case last week with SVGR v4 which broke projects that make use of [custom templates][svgr-template]. It is caused by the SVGR API change from a custom AST parser (H2X) to the powerful [Babel AST][babel-ast] and [rehype][] APIs.
Even when the user uses a `package-lock.json` / `yarn.lock` file it will break as soon as it gets deleted or traverse dependencies are updated because the `@svgr/webpack` package will now be resolved to the latest version.

This commit sets the version to the major version 4 range which means it will resolve all version `>=4.0.0`. Note that this can be seen as a breaking change, but with the wildcard version range used before this Gatsby plugin introduced breaking changes every time a new major version of `@svgr/webpack` has been released.

[babel-ast]: https://github.com/babel/babel/blob/master/packages/babel-parser/ast/spec.md
[svgr-template]: https://github.com/smooth-code/svgr#use-a-specific-template
[rehype]: https://github.com/rehypejs/rehype