### PR TITLE
Nest svgoConfig options under plugins key

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-svgr',
       options: {
-        prettier: true,         // use prettier to format JS code output (default)
-        svgo: true,             // use svgo to optimize SVGs (default)
+        prettier: true,          // use prettier to format JS code output (default)
+        svgo: true,              // use svgo to optimize SVGs (default)
         svgoConfig: {
-          removeViewBox: true, // remove viewBox when possible (default)
-          cleanupIDs: true,    // remove unused IDs and minify remaining IDs (default)
+          plugins: {
+            removeViewBox: true, // remove viewBox when possible (default)
+            cleanupIDs: true,    // remove unused IDs and minify remaining IDs (default)
+          },
         },
       },
     },


### PR DESCRIPTION
I was only able to get svgo configuration working when my options were listed under the `plugins` key. This follows the same format as the svgo YML file shown in the [noted example](https://github.com/zabute/gatsby-plugin-svgr/issues/38#issuecomment-494601002).

I just wanted to make this update in case others wanted to configure svgo with options in the Gatsby plugin!