### PR TITLE
Use "shell" instead of "console" in code block language tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 
 As of v2.0, SVGR is declared as a [peer dependency](https://nodejs.org/en/blog/npm/peer-dependencies/). You will need to add `gatsby-plugin-svgr` as well as `@svgr/webpack` to your dependencies.
 
-```console
+```shell
 $ npm install @svgr/webpack gatsby-plugin-svgr
 ```
 or
-```console
+```shell
 $ yarn add @svgr/webpack gatsby-plugin-svgr
 ```
 


### PR DESCRIPTION
This is to silence prism highlighter warnings, since `console` is [not a supported language tag, while `shell` or `bash` are](https://prismjs.com/#supported-languages). Thanks!