### PR TITLE
Update url-loader test regex for compatibility with Gatsby ^2.30.0

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -9,11 +9,11 @@ exports.onCreateWebpackConfig = (
 
   const rules = existingConfig.module.rules.map(rule => {
     if(
-      String(rule.test) === String(/\.(ico|svg|jpg|jpeg|png|gif|webp)(\?.*)?$/)
+      String(rule.test) === String(/\.(ico|svg|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/)
     ) {
       return {
         ...rule,
-        test: /\.(ico|jpg|jpeg|png|gif|webp)(\?.*)?$/
+        test: /\.(ico|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/
       }
     }
 


### PR DESCRIPTION
Gatsby v2.30 introduced support for the AVIF image format. This involved a change to the `test` regular expression of the Webpack rule Gatsby uses to load image assets. As a result, `gatsby-plugin-svgr` fails to find this rule in the Webpack config it attempts to modify.

This PR updates the strings used by this plugin to find, then modify, the url-loader Webpack rule set by Gatsby.