### PR TITLE
refactor: add more params for better scalability

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -2,30 +2,26 @@ const resolve = (module) => require.resolve(module)
 
 exports.onCreateWebpackConfig = (
   { getConfig, actions, stage, loaders },
-  { plugins, include, exclude, ...svgrOptions }
+  {
+    plugins,
+    include,
+    exclude,
+    nonJsIssuerTest = /\.(?!(js|jsx|ts|tsx)$)([^.]+$)/,
+    svgrIssuerTest = /\.(js|jsx|ts|tsx)$/,
+    preGatsbyConfigTest = /\.(ico|svg|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/,
+    curGatsbyConfigTest = /\.(ico|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/,
+    ...svgrOptions
+  }
 ) => {
   const { replaceWebpackConfig, setWebpackConfig } = actions
   const existingConfig = getConfig()
 
   const rules = existingConfig.module.rules.map((rule) => {
-    // Gatsby < 2.3.0 (no AVIF support)
-    if (
-      String(rule.test) === String(/\.(ico|svg|jpg|jpeg|png|gif|webp)(\?.*)?$/)
-    ) {
+    // see: https://github.com/gatsbyjs/gatsby/blob/release/2.30/packages/gatsby/src/utils/webpack-utils.ts#L518
+    if (String(rule.test) === String(preGatsbyConfigTest)) {
       return {
         ...rule,
-        test: /\.(ico|jpg|jpeg|png|gif|webp)(\?.*)?$/,
-      }
-    }
-
-    // Gatsby ≥ 2.3.0 (AVIF support)
-    if (
-      String(rule.test) ===
-      String(/\.(ico|svg|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/)
-    ) {
-      return {
-        ...rule,
-        test: /\.(ico|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/,
+        test: curGatsbyConfigTest,
       }
     }
 
@@ -47,7 +43,7 @@ exports.onCreateWebpackConfig = (
     test: /\.svg$/,
     use: [urlLoader],
     issuer: {
-      test: /\.(?!(js|jsx|ts|tsx)$)([^.]+$)/,
+      test: nonJsIssuerTest,
     },
   }
 
@@ -61,7 +57,7 @@ exports.onCreateWebpackConfig = (
     test: /\.svg$/,
     use: [svgrLoader, urlLoader],
     issuer: {
-      test: /\.(js|jsx|ts|tsx)$/,
+      test: svgrIssuerTest,
     },
     include,
     exclude,


### PR DESCRIPTION
docz issue: https://github.com/doczjs/docz/issues/1382

Thank you very much for your `gatsby-plugin-svgr`

I'm using [docz](https://github.com/doczjs/docz) and found that the current configuration doesn't support `.mdx` files, So I rewrote part of the code to support docz.

the default params is:
```js
module.exports = {
  plugins: [
    {
      resolve: 'gatsby-plugin-svgr',
      options: {
        nonJsIssuerTest: /\.(?!(js|jsx|ts|tsx)$)([^.]+$)/,
        svgrIssuerTest: /\.(js|jsx|ts|tsx)$/,
        preGatsbyConfigTest: /\.(ico|svg|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/,
        curGatsbyConfigTest: /\.(ico|jpg|jpeg|png|gif|webp|avif)(\?.*)?$/
      },
    },
  ],
}
```

I think the default params is compatible with both Gatsby < 2.3.0 and Gatsby ≥ 2.3.0 , because `ico|svg|jpg|jpeg|png|gif|webp|avif` includes `ico|jpg|jpeg|png|gif|webp`，but not very sure.

The following parameters make it possible to work properly in docz:  

```js
module.exports = {
  plugins: [
    {
      resolve: 'gatsby-plugin-svgr',
      options: {
        nonJsIssuerTest: /\.(?!(js|jsx|ts|tsx|mdx)$)([^.]+$)/,
        svgrIssuerTest: /\.(js|jsx|ts|tsx|mdx)$/,
      },
    },
  ],
}
```

Also, If gatsby's [rule.test](https://github.com/gatsbyjs/gatsby/blob/release/2.30/packages/gatsby/src/utils/webpack-utils.ts#L518) changes later, we can adjust the params to support.  

If this Pull Request is passed, maybe we should also update the README, my English is not very good, I hope you can help to update it.