### PR TITLE
Allows for query params in SVG import statements

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -44,7 +44,7 @@ exports.onCreateWebpackConfig = (
 
   // for non-javascript issuers
   const nonJs = {
-    test: /\.svg$/,
+    test: /\.svg(\?.*)?$/,
     use: [urlLoader],
     issuer: {
       test: /\.(?!(js|jsx|ts|tsx)$)([^.]+$)/,
@@ -58,7 +58,7 @@ exports.onCreateWebpackConfig = (
 
   // add new svg rule
   const svgrRule = {
-    test: /\.svg$/,
+    test: /\.svg(\?.*)?$/,
     use: [svgrLoader, urlLoader],
     issuer: {
       test: /\.(js|jsx|ts|tsx)$/,
@@ -69,7 +69,7 @@ exports.onCreateWebpackConfig = (
 
   // for excluded assets
   const excludedRule = {
-    test: /\.svg$/,
+    test: /\.svg(\?.*)?$/,
     use: urlLoader,
     issuer: svgrRule.issuer,
     include: exclude,


### PR DESCRIPTION
Gatsby's out-of-the-box config matches the following import statements:

    import someIcon from './some-icon.svg';
    import someOtherIcon from './some-other-icon.svg?key=value';

That is, you can import `file.svg?query-params-here` and it'll be matched, even though that module doesn't strictly end in `.svg`.

To keep that same functionality, we just need to adjust our `test` regular expression to more closely match what Gatsby previously had set.

This is useful if you are using things like [svg-transform-loader](https://www.npmjs.com/package/svg-transform-loader).