### PR TITLE
support gatsbyjs-v3

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -47,7 +47,7 @@ exports.onCreateWebpackConfig = (
     test: /\.svg$/,
     use: [urlLoader],
     issuer: {
-      test: /\.(?!(js|jsx|ts|tsx)$)([^.]+$)/,
+      and: [/\.(?!(js|jsx|ts|tsx)$)([^.]+$)/],
     },
   }
 
@@ -61,7 +61,7 @@ exports.onCreateWebpackConfig = (
     test: /\.svg$/,
     use: [svgrLoader, urlLoader],
     issuer: {
-      test: /\.(js|jsx|ts|tsx)$/,
+      and: [/\.(js|jsx|ts|tsx)$/],
     },
     include,
     exclude,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "MIT",
   "peerDependencies": {
     "@svgr/webpack": ">=2.0.0",
-    "gatsby": ">=2.0.0"
+    "gatsby": ">=3.0.0"
   }
 }


### PR DESCRIPTION
mainly modify the `issuer` property.

documentation on Webpack5 `issuer` property.
[https://webpack.js.org/configuration/module/#ruleissuer](https://webpack.js.org/configuration/module/#ruleissuer)