### PR TITLE
Add limit to url-loader

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -40,7 +40,10 @@ exports.onCreateWebpackConfig = (
     },
   })
 
-  const urlLoader = loaders.url({ name: "static/[name].[hash:8].[ext]" })
+  const urlLoader = loaders.url({ 
+    name: "static/[name].[hash:8].[ext]",
+    limit: 10000,
+  })
 
   // for non-javascript issuers
   const nonJs = {


### PR DESCRIPTION
Echo Gatsby's file-size limit for inlining image files which is set to 10000 bytes / 10kb. Without this addition, any svgs that are imported via URLs as opposed to SVGR React components will be inlined into packages, regardless of file-size, for bigger SVGs or pages with many SVGs this can be a serious performance issue.

Closes #54 